### PR TITLE
fix: create project notification

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ export function activate(context: vscode.ExtensionContext) {
 			if (message.command === 'createProject') {
 				const { projectName, projectType } = message;
 
-				vscode.window.showInformationMessage(message);
+				vscode.window.showInformationMessage(`Create ${projectName}, ${projectType}`);
 			}
 			});
 		}


### PR DESCRIPTION
This pull request should fix the notification shown after clicking the "create project" button.
The `vscode.window.showInformationMessage` was given an object, but it expects a string as a first argument.